### PR TITLE
[FIX] ECS 환경을 위한 JPA, MySQL 관련 코드 제거

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,10 +38,6 @@ dependencies {
 	// .env
 	implementation 'io.github.cdimascio:dotenv-java:2.2.4'
 
-	// DB
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-
 	// jwt
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/src/main/java/acc/firewatch/cctv/repository/CctvRepository.java
+++ b/src/main/java/acc/firewatch/cctv/repository/CctvRepository.java
@@ -1,4 +1,4 @@
-package acc.firewatch.cctv.Repository;
+package acc.firewatch.cctv.repository;
 
 import acc.firewatch.cctv.entity.CctvItem;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/acc/firewatch/cctv/service/CctvService.java
+++ b/src/main/java/acc/firewatch/cctv/service/CctvService.java
@@ -1,6 +1,6 @@
 package acc.firewatch.cctv.service;
 
-import acc.firewatch.cctv.Repository.CctvRepository;
+import acc.firewatch.cctv.repository.CctvRepository;
 import acc.firewatch.cctv.dto.CctvRequestDto;
 import acc.firewatch.cctv.dto.CctvResponseDto;
 import acc.firewatch.cctv.entity.CctvItem;

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,8 +1,17 @@
 aws:
+  credentials:
+    access-key: ${AWS_ACCESS_KEY}
+    secret-key: ${AWS_SECRET_KEY}
   dynamodb:
-    region: ${REGION}
+    region: ${DYNAMO_REGION}
     access-key: ${DYNAMO_ACCESS}
     secret-key: ${DYNAMO_SECRET}
+  sqs:
+    enabled: true
+    stack:
+      auto: false
+    region:
+      static: ${SQS_REGION}
 
 server:
   port: 8080

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,25 +1,3 @@
-spring:
-  datasource:
-    url: jdbc:mysql://localhost:3306/loadtest
-    username: root
-    password: 1234
-    driver-class-name: com.mysql.cj.jdbc.Driver
-  sql:
-    init:
-      mode: never
-  jpa:
-    hibernate:
-      ddl-auto: create
-    show-sql: true
-    properties:
-      hibernate:
-        format_sql: true
-    database-platform: org.hibernate.dialect.MySQL8Dialect
-  data:
-    redis:
-      host: localhost
-      port: 6379
-
 aws:
   dynamodb:
     region: ${REGION}


### PR DESCRIPTION
### 문제 상황
1. 프로젝트에는 여전히 spring-boot-starter-data-jpa, mysql-connector-j가 있음
2. application-prod.yml에서는 spring.datasource.url, username, password가 없음
3. Spring Boot는 MySQL에 연결하려 하지만 연결 정보가 없어서
`"Failed to configure a DataSource: 'url' attribute is not specified"` 에러 발생

### 해결 방안
DynamoDB 기반으로 기능 전체를 이관 중이고 MySQL은 더 이상 사용하지 않을 예정이기 때문에 관련 코드를 전체 제거했습니다.