### PR TITLE
[FEATURE] redis로 refresh 토큰 관리하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,11 @@ dependencies {
 	implementation platform('software.amazon.awssdk:bom:2.20.85')
 	implementation 'software.amazon.awssdk:dynamodb-enhanced'
 
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.data:spring-data-redis'
+	implementation 'io.lettuce:lettuce-core'
+
 	// test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: "3.8"
+services:
+  app-server:
+    image: ${DOCKER_USERNAME}/${DOCKER_REPO}
+    ports:
+      - "8080:8080"
+    environment:
+      - SPRING_PROFILES_ACTIVE=prod
+      - AWS_ACCESS_KEY=${AWS_ACCESS_KEY}
+      - AWS_SECRET_KEY=${AWS_SECRET_KEY}
+      - DYNAMO_REGION=${DYNAMO_REGION}
+      - DYNAMO_ACCESS=${DYNAMO_ACCESS}
+      - DYNAMO_SECRET=${DYNAMO_SECRET}
+      - SQS_REGION=${SQS_REGION}
+      - JWT_SECRET=${JWT_SECRET}
+      - ACCESS_EXPIRATION=${ACCESS_EXPIRATION}
+      - REFRESH_EXPIRATION=${REFRESH_EXPIRATION}
+      - ITS_KEY=${ITS_KEY}
+      - VWORLD_KEY=${VWORLD_KEY}
+
+  redis:
+    image: redis:7.2
+    container_name: redis-server
+    ports:
+      - "6379:6379"

--- a/src/main/java/acc/firewatch/common/exception/ErrorCode.java
+++ b/src/main/java/acc/firewatch/common/exception/ErrorCode.java
@@ -28,6 +28,11 @@ public enum ErrorCode {
     INVALID_REFRESH_TOKEN(400,"유효하지 않은 refresh 토큰입니다."),
     REFRESH_TOKEN_MISMATCH(400,"멤버에 저장된 refresh 토큰과 일치하지 않습니다."),
 
+    // security
+    AUTHENTICATION_INFO_NOT_FOUND(401, "인증 정보가 존재하지 않습니다."),
+    INVALID_AUTH_PRINCIPAL(403, "인증된 사용자 정보 형식이 올바르지 않습니다."),
+    INVALID_MEMBER_ID_IN_TOKEN(400, "토큰에서 memberId를 추출할 수 없습니다."),
+
     // cctv
     CCTV_CSV_SAVE_ERROR(500,"CCTV CSV 저장 중 오류 발생"),
     DYNAMO_CCTV_NOT_FOUND(400, "DynamoDB에서 해당 cctvItem을 찾을 수 없습니다."),

--- a/src/main/java/acc/firewatch/config/RedisConfig.java
+++ b/src/main/java/acc/firewatch/config/RedisConfig.java
@@ -1,0 +1,43 @@
+package acc.firewatch.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+    @Bean
+    @Primary
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        // Key와 Value 모두 StringRedisSerializer 사용
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+
+        redisTemplate.afterPropertiesSet();
+        return redisTemplate;
+    }
+
+}

--- a/src/main/java/acc/firewatch/config/jwt/CustomUserPrincipal.java
+++ b/src/main/java/acc/firewatch/config/jwt/CustomUserPrincipal.java
@@ -1,0 +1,12 @@
+package acc.firewatch.config.jwt;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class CustomUserPrincipal {
+    private final Long memberId;
+    private final String phoneNum;
+}

--- a/src/main/java/acc/firewatch/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/acc/firewatch/config/jwt/JwtAuthenticationFilter.java
@@ -35,6 +35,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         return path.startsWith("/swagger") ||
                 path.startsWith("/v3/api-docs") ||
                 path.startsWith("/members/auth") ||
+                path.startsWith("/debug") ||
                 path.startsWith("/h2") ||
                 path.startsWith("/webjars");
     }

--- a/src/main/java/acc/firewatch/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/acc/firewatch/config/jwt/JwtTokenProvider.java
@@ -61,9 +61,10 @@ public class JwtTokenProvider {
     public Authentication getAuthentication(String token) {
         Claims claims = parseClaims(token);
         String phoneNum = claims.getSubject();
+        Long memberId = claims.get("memberId", Long.class);
 
         return new UsernamePasswordAuthenticationToken(
-                phoneNum,
+                new CustomUserPrincipal(memberId, phoneNum),
                 null,
                 Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER")) // or emptyList
         );

--- a/src/main/java/acc/firewatch/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/acc/firewatch/config/jwt/JwtTokenProvider.java
@@ -2,12 +2,12 @@ package acc.firewatch.config.jwt;
 
 import acc.firewatch.common.exception.CustomException;
 import acc.firewatch.common.exception.ErrorCode;
+import acc.firewatch.config.security.CustomUserPrincipal;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;

--- a/src/main/java/acc/firewatch/config/security/CustomUserPrincipal.java
+++ b/src/main/java/acc/firewatch/config/security/CustomUserPrincipal.java
@@ -1,6 +1,5 @@
-package acc.firewatch.config.jwt;
+package acc.firewatch.config.security;
 
-import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/acc/firewatch/config/security/SecurityConfig.java
+++ b/src/main/java/acc/firewatch/config/security/SecurityConfig.java
@@ -1,4 +1,4 @@
-package acc.firewatch.config;
+package acc.firewatch.config.security;
 
 import acc.firewatch.config.jwt.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/acc/firewatch/config/security/SecurityConfig.java
+++ b/src/main/java/acc/firewatch/config/security/SecurityConfig.java
@@ -32,6 +32,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/members/auth/**",
+                                "/debug/**",
                                 "/h2/**",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",

--- a/src/main/java/acc/firewatch/config/security/SecurityUtil.java
+++ b/src/main/java/acc/firewatch/config/security/SecurityUtil.java
@@ -1,0 +1,40 @@
+package acc.firewatch.config.security;
+
+import acc.firewatch.common.exception.CustomException;
+import acc.firewatch.common.exception.ErrorCode;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class SecurityUtil {
+
+    public static Long getCurrentMemberId() {
+        Authentication authentication = getAuthenticationOrThrow();
+
+        if (!(authentication.getPrincipal() instanceof CustomUserPrincipal principal)) {
+            throw new CustomException(ErrorCode.INVALID_AUTH_PRINCIPAL);
+        }
+
+        return principal.getMemberId();
+    }
+
+    public static String getCurrentPhoneNum() {
+        Authentication authentication = getAuthenticationOrThrow();
+
+        if (!(authentication.getPrincipal() instanceof CustomUserPrincipal principal)) {
+            throw new CustomException(ErrorCode.INVALID_AUTH_PRINCIPAL);
+        }
+
+        return principal.getPhoneNum();
+    }
+
+    private static Authentication getAuthenticationOrThrow() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new CustomException(ErrorCode.AUTHENTICATION_INFO_NOT_FOUND);
+        }
+
+        return authentication;
+    }
+}
+

--- a/src/main/java/acc/firewatch/debug/controller/DebugController.java
+++ b/src/main/java/acc/firewatch/debug/controller/DebugController.java
@@ -3,38 +3,39 @@ package acc.firewatch.debug.controller;
 import acc.firewatch.common.response.dto.CustomResponse;
 import acc.firewatch.common.response.dto.SuccessStatus;
 import acc.firewatch.debug.service.DebugService;
+import acc.firewatch.member.dto.MemberResponseDto;
+import acc.firewatch.member.entity.MemberItem;
+import acc.firewatch.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.Set;
 
 @Profile("local")
 @RestController
-@RequestMapping("/debug")
+@RequestMapping("/dev")
 @RequiredArgsConstructor
 public class DebugController {
 
     private final DebugService debugService;
+    private final MemberService memberService;
 
     @Operation(summary = "멤버 ID로 refresh 토큰 조회 API", description = "redis에 저장된 멤버 ID에 해당하는 refresh 토큰을 조회합니다.")
-    @GetMapping("/redis/refresh-token/{id}")
+    @GetMapping("/refresh-token/{id}")
     public CustomResponse<String> getRefreshToken(@PathVariable Long id) {
         return CustomResponse.success(debugService.getRefreshTokenFromRedis(id), SuccessStatus.SUCCESS);
     }
 
     @Operation(summary = "모든 Key 조회 API", description = "redis에 저장된 모든 Key를 조회합니다.")
-    @GetMapping("/redis/refresh-token/keys")
+    @GetMapping("/refresh-token/keys")
     public CustomResponse<Set<String>> listAllRefreshTokenKeys() {
         return CustomResponse.success(debugService.listRefreshTokenKeys(),SuccessStatus.SUCCESS);
     }
 
     @Operation(summary = "refresh 토큰의 TTL 조회 API", description = "redis에 저장된 멤버 ID에 해당하는 refresh 토큰의 TTL을 조회합니다.")
-    @GetMapping("/redis/refresh-token/{id}/ttl")
+    @GetMapping("/refresh-token/{id}/ttl")
     public CustomResponse<Long> getRefreshTokenTTL(@PathVariable Long id) {
         return CustomResponse.success(debugService.getRefreshTokenTTL(id), SuccessStatus.SUCCESS);
     }

--- a/src/main/java/acc/firewatch/debug/controller/DebugController.java
+++ b/src/main/java/acc/firewatch/debug/controller/DebugController.java
@@ -32,4 +32,11 @@ public class DebugController {
     public CustomResponse<Set<String>> listAllRefreshTokenKeys() {
         return CustomResponse.success(debugService.listRefreshTokenKeys(),SuccessStatus.SUCCESS);
     }
+
+    @Operation(summary = "refresh 토큰의 TTL 조회 API", description = "redis에 저장된 멤버 ID에 해당하는 refresh 토큰의 TTL을 조회합니다.")
+    @GetMapping("/redis/refresh-token/{id}/ttl")
+    public CustomResponse<Long> getRefreshTokenTTL(@PathVariable Long id) {
+        return CustomResponse.success(debugService.getRefreshTokenTTL(id), SuccessStatus.SUCCESS);
+    }
+
 }

--- a/src/main/java/acc/firewatch/debug/controller/DebugController.java
+++ b/src/main/java/acc/firewatch/debug/controller/DebugController.java
@@ -1,0 +1,35 @@
+package acc.firewatch.debug.controller;
+
+import acc.firewatch.common.response.dto.CustomResponse;
+import acc.firewatch.common.response.dto.SuccessStatus;
+import acc.firewatch.debug.service.DebugService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Set;
+
+@Profile("local")
+@RestController
+@RequestMapping("/debug")
+@RequiredArgsConstructor
+public class DebugController {
+
+    private final DebugService debugService;
+
+    @Operation(summary = "멤버 ID로 refresh 토큰 조회 API", description = "redis에 저장된 멤버 ID에 해당하는 refresh 토큰을 조회합니다.")
+    @GetMapping("/redis/refresh-token/{id}")
+    public CustomResponse<String> getRefreshToken(@PathVariable Long id) {
+        return CustomResponse.success(debugService.getRefreshTokenFromRedis(id), SuccessStatus.SUCCESS);
+    }
+
+    @Operation(summary = "모든 Key 조회 API", description = "redis에 저장된 모든 Key를 조회합니다.")
+    @GetMapping("/redis/refresh-token/keys")
+    public CustomResponse<Set<String>> listAllRefreshTokenKeys() {
+        return CustomResponse.success(debugService.listRefreshTokenKeys(),SuccessStatus.SUCCESS);
+    }
+}

--- a/src/main/java/acc/firewatch/debug/service/DebugService.java
+++ b/src/main/java/acc/firewatch/debug/service/DebugService.java
@@ -1,0 +1,25 @@
+package acc.firewatch.debug.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.Set;
+
+@Service
+@Profile("local")
+@RequiredArgsConstructor
+public class DebugService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public String getRefreshTokenFromRedis(Long memberId) {
+        return redisTemplate.opsForValue().get("refresh_token:" + memberId);
+    }
+
+    public Set<String> listRefreshTokenKeys() {
+        return redisTemplate.keys("refresh_token:*");
+    }
+
+}

--- a/src/main/java/acc/firewatch/debug/service/DebugService.java
+++ b/src/main/java/acc/firewatch/debug/service/DebugService.java
@@ -22,4 +22,8 @@ public class DebugService {
         return redisTemplate.keys("refresh_token:*");
     }
 
+    public Long getRefreshTokenTTL(Long memberId) {
+        return redisTemplate.getExpire("refresh_token:" + memberId);
+    }
+
 }

--- a/src/main/java/acc/firewatch/member/controller/MemberController.java
+++ b/src/main/java/acc/firewatch/member/controller/MemberController.java
@@ -2,6 +2,7 @@ package acc.firewatch.member.controller;
 
 import acc.firewatch.common.response.dto.CustomResponse;
 import acc.firewatch.common.response.dto.SuccessStatus;
+import acc.firewatch.config.security.SecurityUtil;
 import acc.firewatch.member.dto.*;
 import acc.firewatch.member.entity.MemberItem;
 import acc.firewatch.member.service.AuthService;
@@ -94,8 +95,8 @@ public class MemberController {
             )
     })
     @PostMapping("/auth/reissue")
-    public CustomResponse<TokenResponse> reissue(@RequestBody TokenReissueRequest request) {
-        TokenResponse response = authService.reissueToken(request.getRefreshToken());
+    public CustomResponse<TokenReissueResponseDto> reissue(@RequestBody TokenReissueRequestDto request) {
+        TokenReissueResponseDto response = authService.reissueToken(request.getRefreshToken());
         return CustomResponse.success(response, SuccessStatus.TOKEN_REISSUE_OK);
     }
 
@@ -114,9 +115,8 @@ public class MemberController {
     })
     @PostMapping("/me/logout")
     public CustomResponse<?> logout() {
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        String phoneNum = (String) auth.getPrincipal();
-        memberService.logout(phoneNum);
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        authService.logout(memberId);
         return CustomResponse.success(SuccessStatus.LOGOUT_MEMBER_OK);
     }
 
@@ -135,9 +135,7 @@ public class MemberController {
     })
     @GetMapping("/me")
     public CustomResponse<MemberResponseDto> getMyInfo() {
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        String phoneNum = (String) auth.getPrincipal(); // Jwt에서 설정한 값
-
+        String phoneNum = SecurityUtil.getCurrentPhoneNum();
         return CustomResponse.success(memberService.getMyInfo(phoneNum), SuccessStatus.GET_MY_INFO_OK);
     }
 
@@ -156,8 +154,7 @@ public class MemberController {
     })
     @PatchMapping("/me")
     public CustomResponse<MemberResponseDto> updateMyInfo(@RequestBody MemberUpdateRequestDto requestDto) {
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        String phoneNum = (String) auth.getPrincipal();
+        String phoneNum = SecurityUtil.getCurrentPhoneNum();
         MemberResponseDto responseDto = memberService.updateMyInfo(phoneNum, requestDto);
         return CustomResponse.success(responseDto, SuccessStatus.UPDATE_MY_INFO_OK);
     }
@@ -186,9 +183,7 @@ public class MemberController {
     })
     @PatchMapping("/me/password")
     public CustomResponse<?> changePassword(@RequestBody PasswordChangeRequestDto dto) {
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        String phoneNum = (String) auth.getPrincipal();
-
+        String phoneNum = SecurityUtil.getCurrentPhoneNum();
         memberService.changePassword(phoneNum, dto);
         return CustomResponse.success(SuccessStatus.UPDATE_PASSWORD);
     }

--- a/src/main/java/acc/firewatch/member/controller/MemberController.java
+++ b/src/main/java/acc/firewatch/member/controller/MemberController.java
@@ -188,32 +188,6 @@ public class MemberController {
         return CustomResponse.success(SuccessStatus.UPDATE_PASSWORD);
     }
 
-    @Operation(summary = "ID로 단건 조회 API", description = "파티션 키로 한 건을 조회합니다.")
-    @GetMapping("/{id}")
-    public CustomResponse<MemberResponseDto> getById(@PathVariable Long id) {
-        MemberItem member = memberService.getById(id);
-
-        return CustomResponse.success(
-                MemberResponseDto.builder()
-                        .id(member.getId())
-                        .name(member.getName())
-                        .phoneNum(member.getPhoneNum())
-                        .verified(member.isVerified())
-                        .city(member.getCity())
-                        .district(member.getDistrict())
-                        .detail(member.getDetail())
-                        .build(),
-                SuccessStatus.DYNAMO_MEMBER_GET
-        );
-    }
-
-    @Operation(summary = "ID로 단건 레코드 삭제 API", description = "파티션 키에 해당하는 레코드를 삭제합니다.")
-    @DeleteMapping("/{id}")
-    public CustomResponse<String> deleteById(@PathVariable Long id) {
-        memberService.deleteById(id);
-        return CustomResponse.success("memberItem id = " + id + "삭제 완료", SuccessStatus.DYNAMO_MEMBER_DELETE);
-    }
-
     @Operation(summary = "주소 기준 전체 MEMBER 조회 API", description = "주소(city + district)에 해당하는 전체 MEMBER를 조회합니다.")
     @GetMapping("/search")
     public CustomResponse<MemberAddressSearchResponseDto> findByAddress(@RequestParam String address) {
@@ -221,5 +195,12 @@ public class MemberController {
                 memberService.findByAddress(address),
                 SuccessStatus.DYNAMO_MEMBER_GET
         );
+    }
+
+    @Operation(summary = "ID로 멤버 레코드 삭제 API", description = "멤버 테이블에서 파티션 키에 해당하는 레코드를 삭제합니다.")
+    @DeleteMapping("/members/{id}")
+    public CustomResponse<String> deleteById(@PathVariable Long id) {
+        memberService.deleteById(id);
+        return CustomResponse.success("memberItem id = " + id + "삭제 완료", SuccessStatus.DYNAMO_MEMBER_DELETE);
     }
 }

--- a/src/main/java/acc/firewatch/member/dto/TokenReissueRequestDto.java
+++ b/src/main/java/acc/firewatch/member/dto/TokenReissueRequestDto.java
@@ -3,6 +3,6 @@ package acc.firewatch.member.dto;
 import lombok.Getter;
 
 @Getter
-public class TokenReissueRequest {
+public class TokenReissueRequestDto {
     private String refreshToken;
 }

--- a/src/main/java/acc/firewatch/member/dto/TokenReissueResponseDto.java
+++ b/src/main/java/acc/firewatch/member/dto/TokenReissueResponseDto.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class TokenResponse {
+public class TokenReissueResponseDto {
     private String accessToken;
     private String refreshToken;
 }

--- a/src/main/java/acc/firewatch/member/entity/MemberItem.java
+++ b/src/main/java/acc/firewatch/member/entity/MemberItem.java
@@ -23,7 +23,6 @@ public class MemberItem {
     private String address; // city+district
 
     private boolean verified;
-    private String refreshToken;
 
     @DynamoDbPartitionKey
     public Long getId(){

--- a/src/main/java/acc/firewatch/member/service/AuthService.java
+++ b/src/main/java/acc/firewatch/member/service/AuthService.java
@@ -5,10 +5,10 @@ import acc.firewatch.common.exception.ErrorCode;
 import acc.firewatch.config.jwt.JwtTokenProvider;
 import acc.firewatch.member.dto.TokenReissueResponseDto;
 import acc.firewatch.member.entity.MemberItem;
+import acc.firewatch.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 
@@ -18,7 +18,7 @@ public class AuthService {
 
     private final RedisTemplate<String, String> redisTemplate;
     private final JwtTokenProvider jwtTokenProvider;
-    private final MemberService memberService;
+    private final MemberRepository memberRepository;
 
     public TokenReissueResponseDto reissueToken(String refreshToken) {
 
@@ -39,7 +39,7 @@ public class AuthService {
         }
 
         // 사용자 정보 조회
-        MemberItem memberItem = memberService.getById(memberId);
+        MemberItem memberItem = memberRepository.getById(memberId);
         if (memberItem == null) {
             throw new CustomException(ErrorCode.MEMBER_NOT_FOUND);
         }
@@ -55,7 +55,6 @@ public class AuthService {
         return new TokenReissueResponseDto(newAccessToken, newRefreshToken);
     }
 
-    @Transactional
     public void logout(Long memberId) {
         String redisKey = "refresh_token:" + memberId;
         redisTemplate.delete(redisKey);

--- a/src/main/java/acc/firewatch/member/service/AuthService.java
+++ b/src/main/java/acc/firewatch/member/service/AuthService.java
@@ -3,19 +3,24 @@ package acc.firewatch.member.service;
 import acc.firewatch.common.exception.CustomException;
 import acc.firewatch.common.exception.ErrorCode;
 import acc.firewatch.config.jwt.JwtTokenProvider;
-import acc.firewatch.member.dto.TokenResponse;
+import acc.firewatch.member.dto.TokenReissueResponseDto;
 import acc.firewatch.member.entity.MemberItem;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
 
 @Service
 @RequiredArgsConstructor
 public class AuthService {
 
+    private final RedisTemplate<String, String> redisTemplate;
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberService memberService;
 
-    public TokenResponse reissueToken(String refreshToken) {
+    public TokenReissueResponseDto reissueToken(String refreshToken) {
 
         // refresh 토큰 유효성 확인
         if (!jwtTokenProvider.validateToken(refreshToken)) {
@@ -25,19 +30,35 @@ public class AuthService {
         // claims에서 memberId 추출
         Long memberId = jwtTokenProvider.parseClaims(refreshToken).get("memberId", Long.class);
 
-        // DynamoDB에서 사용자 정보 조회
-        MemberItem memberItem = memberService.getById(memberId);
-        if (memberItem == null || !refreshToken.equals(memberItem.getRefreshToken())) {
+        // Redis에서 refresh token 조회
+        String redisKey = "refresh_token:" + memberId;
+        String storedRefreshToken = redisTemplate.opsForValue().get(redisKey);
+
+        if (storedRefreshToken == null || !storedRefreshToken.equals(refreshToken)) {
             throw new CustomException(ErrorCode.REFRESH_TOKEN_MISMATCH);
+        }
+
+        // 사용자 정보 조회
+        MemberItem memberItem = memberService.getById(memberId);
+        if (memberItem == null) {
+            throw new CustomException(ErrorCode.MEMBER_NOT_FOUND);
         }
 
         // 새 토큰 발급 및 저장
         String newAccessToken = jwtTokenProvider.generateToken(memberItem.getPhoneNum(), memberItem.getId());
         String newRefreshToken = jwtTokenProvider.generateRefreshToken(memberItem.getPhoneNum(), memberItem.getId());
 
-        // DynamoDB에 새로운 refreshToken 갱신
-        memberService.updateRefreshToken(memberId, newRefreshToken);
+        // Redis에 새 Refresh Token 저장 (TTL 7일)
+        redisTemplate.delete(redisKey);
+        redisTemplate.opsForValue().set(redisKey, newRefreshToken, Duration.ofDays(7));
 
-        return new TokenResponse(newAccessToken, newRefreshToken);
+        return new TokenReissueResponseDto(newAccessToken, newRefreshToken);
     }
+
+    @Transactional
+    public void logout(Long memberId) {
+        String redisKey = "refresh_token:" + memberId;
+        redisTemplate.delete(redisKey);
+    }
+
 }

--- a/src/main/java/acc/firewatch/member/service/MemberService.java
+++ b/src/main/java/acc/firewatch/member/service/MemberService.java
@@ -161,19 +161,9 @@ public class MemberService {
                 .build();
     }
 
-    // ID로 단건 조회
-    public MemberItem getById(Long id) {
-        MemberItem member = memberRepository.getById(id);
-        if (member == null) {
-            throw new CustomException(ErrorCode.MEMBER_NOT_FOUND);
-        }
-        return member;
-    }
-
-    // id에 해당하는 레코드 삭제
+    // id에 해당하는 멤버 레코드 삭제
     public void deleteById(Long id) {
         memberRepository.deleteById(id);
         log.info("삭제 완료: id = {}", id);
     }
-
 }

--- a/src/main/java/acc/firewatch/member/service/MemberService.java
+++ b/src/main/java/acc/firewatch/member/service/MemberService.java
@@ -8,9 +8,11 @@ import acc.firewatch.member.entity.MemberItem;
 import acc.firewatch.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
 import java.util.List;
 
 @Service
@@ -18,6 +20,7 @@ import java.util.List;
 @Slf4j
 public class MemberService {
 
+    private final RedisTemplate<String, String> redisTemplate;
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
@@ -43,7 +46,6 @@ public class MemberService {
                 .detail(dto.getDetail())
                 .address(dto.getCity()+ " " +dto.getDistrict()) // city+district. ex) 서울시 강남구
                 .verified(false)
-                .refreshToken(null)
                 .build();
 
         memberRepository.save(member);
@@ -71,8 +73,9 @@ public class MemberService {
         String accessToken = jwtTokenProvider.generateToken(member.getPhoneNum(), member.getId());
         String refreshToken = jwtTokenProvider.generateRefreshToken(member.getPhoneNum(), member.getId());
 
-        member.setRefreshToken(refreshToken);
-        memberRepository.update(member);
+        // Redis에 Refresh Token 저장(TTL 포함)
+        String redisKey = "refresh_token:" + member.getId();
+        redisTemplate.opsForValue().set(redisKey, refreshToken, Duration.ofDays(7));
 
         return LoginResponseDto.builder()
                 .accessToken(accessToken)
@@ -80,15 +83,6 @@ public class MemberService {
                 .name(member.getName())
                 .memberId(member.getId())
                 .build();
-    }
-
-    // 로그아웃
-    public void logout(String phoneNum) {
-        MemberItem member = memberRepository.findByPhoneNum(phoneNum)
-                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
-
-        member.setRefreshToken(null);
-        memberRepository.update(member);
     }
 
     // 내 정보 조회
@@ -165,17 +159,6 @@ public class MemberService {
                 .count(members.size())
                 .members(members)
                 .build();
-    }
-
-    // refreshToken 갱신: null이 아닌 필드들은 모두 갱신되고, null인 필드는 기존 값 유지되는 구조를 활용
-    public void updateRefreshToken(Long memberId, String newRefreshToken) {
-        MemberItem member = getById(memberId);
-        if (member == null) {
-            throw new CustomException(ErrorCode.MEMBER_NOT_FOUND);
-        }
-
-        member.setRefreshToken(newRefreshToken);
-        memberRepository.update(member);
     }
 
     // ID로 단건 조회

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,3 +1,9 @@
+spring:
+  data:
+    redis:
+      host: redis
+      port: 6379
+
 aws:
   credentials:
     access-key: ${AWS_ACCESS_KEY}


### PR DESCRIPTION
### 관련 이슈
closed #7 

---
### 기존 Authentication의 문제점
1. Authentication에는 phoneNum만 저장되어 있음
→ 여기서 memberId를 넣으려면 CustomUserPrincipal를 새로 만들어야 함
2. 로그인 시 redis의 key는 memberId로 저장되어 있음
3. 재발급에는 refresh 토큰 자체에 memberId 값이 들어있어서 redis로 관리할 때는 문제 없음
4. 로그아웃 시에 Authentication에 memberId가 없어서 문제 발생

### CustomUserPrincipal 추가하여 해결
- CustomUserPrincipal에는 memberId, phoneNum을 포함함
- JwtAuthenticationFilter에서 SecurityContext 설정할 때 Authentication 객체 생성 시 CustomUserPrincipal을 principal로 사용
- 또한 SecurityUtil를 추가하여 SecurityContextHolder에서 memberId, phoneNum을 추출하는 메소드를 추가함

### 토큰 재발급, 로그아웃 구현
- key를 memberId로 설정

### 추가사항
- 디버깅용으로 redis에서 refresh 토큰값과 TTL, 저장된 모든 key를 반환하는 메소드를 추가함

---
### 스크린 샷
<img width="865" height="201" alt="스크린샷 2025-07-17 오후 11 34 40" src="https://github.com/user-attachments/assets/af81bd7a-c794-43e3-bda1-b87982ab09e4" />
