### PR TITLE
[FIX] Redis를 ElastiCache 기반으로 전환

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       - "8080:8080"
     environment:
       - SPRING_PROFILES_ACTIVE=prod
+      - REDIS_HOST=${REDIS_HOST}
+      - REDIS_PORT=${REDIS_PORT}
       - AWS_ACCESS_KEY=${AWS_ACCESS_KEY}
       - AWS_SECRET_KEY=${AWS_SECRET_KEY}
       - DYNAMO_REGION=${DYNAMO_REGION}
@@ -17,9 +19,3 @@ services:
       - REFRESH_EXPIRATION=${REFRESH_EXPIRATION}
       - ITS_KEY=${ITS_KEY}
       - VWORLD_KEY=${VWORLD_KEY}
-
-  redis:
-    image: redis:7.2
-    container_name: redis-server
-    ports:
-      - "6379:6379"

--- a/src/main/java/acc/firewatch/config/DynamoDbConfig.java
+++ b/src/main/java/acc/firewatch/config/DynamoDbConfig.java
@@ -14,10 +14,6 @@ public class DynamoDbConfig {
 
     @Value("${aws.dynamodb.region}")
     private String region;
-    @Value("${aws.dynamodb.access-key}")
-    private String accessKey;
-    @Value("${aws.dynamodb.secret-key}")
-    private String secretKey;
 
 
     // DynamoDB Low-Level Client (기본 클라이언트)
@@ -25,11 +21,6 @@ public class DynamoDbConfig {
     public DynamoDbClient dynamoDbClient() {
         return DynamoDbClient.builder()
                 .region(Region.of(region)) // 서울 리전
-                .credentialsProvider(
-                        StaticCredentialsProvider.create(
-                                AwsBasicCredentials.create(accessKey, secretKey)
-                        )
-                )
                 .build();
     }
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,8 +1,10 @@
 spring:
   data:
     redis:
-      host: redis
-      port: 6379
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      ssl:
+        enabled: true
 
 aws:
   credentials:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -7,13 +7,8 @@ spring:
         enabled: true
 
 aws:
-  credentials:
-    access-key: ${AWS_ACCESS_KEY}
-    secret-key: ${AWS_SECRET_KEY}
   dynamodb:
     region: ${DYNAMO_REGION}
-    access-key: ${DYNAMO_ACCESS}
-    secret-key: ${DYNAMO_SECRET}
   sqs:
     enabled: true
     stack:

--- a/task-definition.json
+++ b/task-definition.json
@@ -18,10 +18,12 @@
       "essential": true,
       "environment": [
         {
-          "name": "SPRING_PROFILES_ACTIVE", "value": "prod"
+          "name": "SPRING_PROFILES_ACTIVE",
+          "value": "prod"
         },
         {
-          "name": "SPRING_CONFIG_IMPORT", "value": "optional:aws-secretsmanager:acc/ddd/prod"
+          "name": "SPRING_CONFIG_IMPORT",
+          "value": "optional:aws-secretsmanager:acc/ddd/prod"
         }
       ],
       "logConfiguration": {
@@ -30,25 +32,6 @@
           "awslogs-group": "ecs/spring/ddd-task",
           "awslogs-region": "ap-northeast-2",
           "awslogs-stream-prefix": "app"
-        }
-      }
-    },
-    {
-      "name": "redis",
-      "image": "redis:7.2",
-      "portMappings": [
-        {
-          "containerPort": 6379
-        }
-      ],
-      "essential": true,
-      "command": ["redis-server", "--protected-mode", "no"],
-      "logConfiguration": {
-        "logDriver": "awslogs",
-        "options": {
-          "awslogs-group": "ecs/spring/ddd-task",
-          "awslogs-region": "ap-northeast-2",
-          "awslogs-stream-prefix": "redis"
         }
       }
     }


### PR DESCRIPTION
## 관련 이슈
closed #20 

## Summary
기존 ECS Task 내에 Redis 컨테이너를 사이드카 형태로 띄우던 구조를 제거하고, AWS ElastiCache for Redis로 전환함
이를 통해 네트워크 안정성과 운영 편의성을 확보하고, Spring Boot 애플리케이션은 Secrets Manager에 등록된 Redis 정보를 활용해 연결하도록 수정

## 트러블슈팅

**처음 시도 (ECS 내부 Redis 컨테이너)**

- ECS Fargate에서 app-server와 redis 컨테이너를 같은 Task에 배포
- 하지만 Fargate 네트워크(awsvpc) 특성상 localhost 접근이 불가능했고,
- 컨테이너 DNS(redis)를 통한 접근도 불안정 → RedisConnectionFailureException 지속 발생

**protected-mode 문제**

- Redis 기본 설정(protected-mode yes) 때문에 ECS 내부 통신도 차단됨
- `--protected-mode no` 옵션으로 수정했으나 여전히 네트워크 구조상 불안정

**운영 안정성 문제**

- Redis를 사이드카 컨테이너로 두면 ECS Task 재시작 시 데이터 휘발
- 확장성 부족(스케일 아웃 불가능), 모니터링 및 장애 대응도 제한적

**ElastiCache 전환**

- VPC 내부 프라이빗 서브넷에 ElastiCache 구성
- ECS 서비스 보안 그룹 ↔ ElastiCache 보안 그룹 간 포트 허용
- Secrets Manager에 Redis endpoint/비밀번호 저장 후 Spring Boot에서 참조

## 상세 구현 내용

docker-compose.yml

- 로컬 환경에서는 Redis 컨테이너 제거, 환경변수 기반 연결로 변경

task-definition.json

- Redis 컨테이너 정의 삭제
- app-server 단독 컨테이너 구성
- `SPRING_CONFIG_IMPORT=aws-secretsmanager:acc/ddd/prod` 환경변수 유지

application-prod.yml

- Redis 설정을 ${REDIS_HOST}, ${REDIS_PORT}, ${REDIS_PASSWORD} 기반으로 수정
- ElastiCache 암호화 환경에 맞게 `ssl: true` 옵션 활성화